### PR TITLE
Rename draft to reflect cose WG adoption

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-looker-cose-cwt-claims-in-headers.md tobias.looker@mattr.global
+draft-ietf-cose-cwt-claims-in-headers.md tobias.looker@mattr.global

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .targets.mk
 /*-[0-9][0-9].xml
 archive.json
-draft-looker-cose-cwt-claims-in-headers.xml
+draft-ietf-cose-cwt-claims-in-headers.xml
 lib
 report.xml
 venv/

--- a/.note.xml
+++ b/.note.xml
@@ -1,4 +1,4 @@
 <note title="Discussion Venues" removeInRFC="true">
 <t>Source for this draft and an issue tracker can be found at
-    <eref target="https://github.com/tplooker/draft-looker-cose-cwt-claims-in-headers"/>.</t>
+    <eref target="https://github.com/tplooker/draft-ietf-cose-cwt-claims-in-headers"/>.</t>
 </note>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/tplooker/draft-looker-cose-cwt-claims-in-headers/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/tplooker/draft-ietf-cose-cwt-claims-in-headers/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 This is the working area for the individual Internet-Draft, "CBOR Web Token (CWT) Claims in COSE Headers".
 
-* [Editor's Copy](https://tplooker.github.io/draft-looker-cose-cwt-claims-in-headers/#go.draft-looker-cose-cwt-claims-in-headers.html)
-* [Datatracker Page](https://datatracker.ietf.org/doc/draft-looker-cose-cwt-claims-in-headers)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-looker-cose-cwt-claims-in-headers)
-* [Compare Editor's Copy to Individual Draft](https://tplooker.github.io/draft-looker-cose-cwt-claims-in-headers/#go.draft-looker-cose-cwt-claims-in-headers.diff)
+* [Editor's Copy](https://tplooker.github.io/draft-ietf-cose-cwt-claims-in-headers/#go.draft-ietf-cose-cwt-claims-in-headers.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-cose-cwt-claims-in-headers)
+* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ietf-cose-cwt-claims-in-headers)
+* [Compare Editor's Copy to Individual Draft](https://tplooker.github.io/draft-ietf-cose-cwt-claims-in-headers/#go.draft-ietf-cose-cwt-claims-in-headers.diff)
 
 
 ## Contributing
 
 See the
-[guidelines for contributions](https://github.com/tplooker/draft-looker-cose-cwt-claims-in-headers/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/tplooker/draft-ietf-cose-cwt-claims-in-headers/blob/main/CONTRIBUTING.md).
 
 Contributions can be made by creating pull requests.
 The GitHub interface supports creating pull requests using the Edit (✏) button.

--- a/draft-looker-cose-cwt-claims-in-headers.md
+++ b/draft-looker-cose-cwt-claims-in-headers.md
@@ -78,7 +78,7 @@ IANA is requested to register the new COSE Header parameter in the table in (#re
 
 -00
 
-* Initial version
+* Created draft-ietf-cose-cwt-claims-in-headers-00 from draft-looker-cose-cwt-claims-in-headers-00 following working group adoption.
 
 <reference anchor="IANA.COSE" target="https://www.iana.org/assignments/cose/cose.xhtml#header-parameters">
  <front>

--- a/draft-looker-cose-cwt-claims-in-headers.md
+++ b/draft-looker-cose-cwt-claims-in-headers.md
@@ -8,7 +8,7 @@ keyword = ["COSE", "JOSE"]
 
 [seriesInfo]
 name = "Internet-Draft"
-value = "draft-looker-cose-cwt-claims-in-headers-latest"
+value = "draft-ietf-cose-cwt-claims-in-headers-latest"
 status = "standard"
 
 [pi]


### PR DESCRIPTION
As per the title following the formal adoption by the COSE WG this PR updates the draft name to reflect this.