### PR TITLE
fix: add recommendation around header treatment

### DIFF
--- a/draft-ietf-cose-cwt-claims-in-headers.md
+++ b/draft-ietf-cose-cwt-claims-in-headers.md
@@ -87,6 +87,10 @@ IANA is requested to register the new COSE Header parameter in the table in (#re
 
 # Document History
 
+-03
+
+* Added recommendation around header treatment in protected vs unprotected
+
 -02
 
 * Added CDDL description for CWT claim value.

--- a/draft-ietf-cose-cwt-claims-in-headers.md
+++ b/draft-ietf-cose-cwt-claims-in-headers.md
@@ -69,6 +69,8 @@ CWT-Claims = {
 Claim-Label = int / text
 ```
 
+It is RECOMMENDED that the cwt claims header parameter is used only in a protected header to avoid the contents from being malleable. The header parameter MUST only occur once in either the protected or unprotected header of a COSE structure.
+
 # Privacy Considerations
 
 Some of the registered CWT claims may contain privacy-sensitive information. Therefore care must be taken when expressing CWT claims in COSE headers.

--- a/draft-ietf-cose-cwt-claims-in-headers.md
+++ b/draft-ietf-cose-cwt-claims-in-headers.md
@@ -69,7 +69,7 @@ CWT-Claims = {
 Claim-Label = int / text
 ```
 
-It is RECOMMENDED that the CWT claims header parameter is used only in a protected header to avoid the contents from being malleable. The header parameter MUST only occur once in either the protected or unprotected header of a COSE structure.
+It is RECOMMENDED that the CWT claims header parameter is used only in a protected header to avoid the contents being malleable. The header parameter MUST only occur once in either the protected or unprotected header of a COSE structure.
 
 # Privacy Considerations
 

--- a/draft-ietf-cose-cwt-claims-in-headers.md
+++ b/draft-ietf-cose-cwt-claims-in-headers.md
@@ -57,9 +57,9 @@ This document defines the following COSE header parameter:
 
 |   Name          |  Label | Value Type | Value Registry |   Description   |
 |-----------------|--------|------------|----------------|-----------------|
-|   cwt claims    |  TBD (requested assignment 11)   | map        | [@!IANA.CWT]   | location for CWT claims in  COSE headers   |
+|   CWT claims    |  TBD (requested assignment 11)   | map        | [@!IANA.CWT]   | location for CWT claims in  COSE headers   |
 
-The following is a non-normative description for the value type of the cwt claim header parameter using CDDL [@RFC8610].
+The following is a non-normative description for the value type of the CWT claim header parameter using CDDL [@RFC8610].
 
 ```
 CWT-Claims = {
@@ -69,7 +69,7 @@ CWT-Claims = {
 Claim-Label = int / text
 ```
 
-It is RECOMMENDED that the cwt claims header parameter is used only in a protected header to avoid the contents from being malleable. The header parameter MUST only occur once in either the protected or unprotected header of a COSE structure.
+It is RECOMMENDED that the CWT claims header parameter is used only in a protected header to avoid the contents from being malleable. The header parameter MUST only occur once in either the protected or unprotected header of a COSE structure.
 
 # Privacy Considerations
 

--- a/draft-ietf-cose-cwt-claims-in-headers.md
+++ b/draft-ietf-cose-cwt-claims-in-headers.md
@@ -89,7 +89,7 @@ IANA is requested to register the new COSE Header parameter in the table in (#re
 
 -03
 
-* Added recommendation around header treatment in protected vs unprotected
+* Added recommendation around header treatment in protected vs unprotected.
 
 -02
 


### PR DESCRIPTION
Adds recommendation for the header parameter to only appear in the protected header and guidance for what to do w.r.t duplication across protected and unprotected headers.